### PR TITLE
use file reader for more consistent path resolution

### DIFF
--- a/App/Src/Logic.fs
+++ b/App/Src/Logic.fs
@@ -7,7 +7,8 @@ module Logic =
 
     let convert (filename: string): Result<unit, exn> =
         try
-            let deps = Pom.parseFile filename
+            use fileReader = System.IO.File.OpenText filename
+            let deps = Pom.parseFile fileReader
             printf "%s" (Clj.emit deps)
             Ok ()
         with

--- a/Lib/Src/Pom.fs
+++ b/Lib/Src/Pom.fs
@@ -21,5 +21,5 @@ module Pom =
     let parseString (contents: string): Dependency.t list =
         PomProvider.Parse contents |> extractDependencies
 
-    let parseFile (path: string): Dependency.t list =
-        PomProvider.Load path |> extractDependencies
+    let parseFile (reader: System.IO.TextReader): Dependency.t list =
+        PomProvider.Load reader |> extractDependencies


### PR DESCRIPTION
Instead of passing paths as URIs pass a Reader object and open the file in the application code